### PR TITLE
Revise README for passport contracts clarity

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,12 @@
 
 ## Overview
 
-This is the implementation of contracts for passport verification and management of passport credentials in Privado ID.
+This repository contains smart contracts used for passport-style credential verification within the Privado ID (Billions) ecosystem.
+
+### What these contracts enable
+- On-chain verification of passport credentials
+- Zero-knowledge proof-based validation without exposing user data
+- Reusable verification logic for applications integrating Billions
 
 ## Building contracts
 


### PR DESCRIPTION
### Summary
This PR improves the README by clarifying the purpose of the repository and outlining what the passport verification contracts are responsible for.

### Motivation
The previous README was quite minimal and did not clearly explain the role of these contracts for new contributors or integrators.  
This update aims to improve onboarding, context, and overall documentation clarity without changing any contract logic.
